### PR TITLE
feat: add link to GitHub repo in header

### DIFF
--- a/src/templates/components/header.njk
+++ b/src/templates/components/header.njk
@@ -13,6 +13,9 @@
       <a href="/blog">
         Blog
       </a>
+      <a href="https://github.com/dustinwhisman/eleventy-starter">
+        GitHub
+      </a>
     </div>
   </nav>
 </header>


### PR DESCRIPTION
## Description
For ease of use, add a link to this repo in the site's header.

## Developer Checklist
- [x] All GitHub status checks pass

## Reviewer Checklist
- [x] The PR deploy's home page has a link in the header that links to this repo
