### PR TITLE
fix: put guards in place to prevent errors if all JS files are deleted

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "js:build": "rollup -c && npm run js:minify",
     "js:watch": "chokidar \"**/src/assets/**/*js\" -c \"npm run js:dev\"",
     "lint:css": "stylelint src/**/*.css src/**/*.scss",
-    "lint:js": "eslint src/**/*.js src/**/*.mjs",
+    "lint:js": "eslint src/**/*.js src/**/*.mjs --no-error-on-unmatched-pattern",
     "lint": "run-s lint:css lint:js",
     "test:js": "jest --config=jest.config.js src/assets/js/**/*js --passWithNoTests",
     "node-version": "check-node-version --package",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,15 @@ import { babel } from '@rollup/plugin-babel';
 const files = fs.readdirSync('src/assets/js').filter((file) => file.endsWith('.js') || file.endsWith('.mjs'));
 const configs = [];
 
+if (!files.length) {
+  configs.push({
+    input: 'src/assets/js/.gitkeep',
+    output: {
+      dir: 'dist/assets/js',
+    },
+  });
+}
+
 files.forEach((file) => {
   // modern bundles
   configs.push({


### PR DESCRIPTION
## Description
Change configs such that if a user deletes the example JS files, they won't get error messages from running or linting the project.

## Developer Checklist
- [ ] All GitHub status checks pass
- [x] Commits are squashed and rebased on top of the target branch
