### PR TITLE
chore: only run Lighthouse workflow when `src/**` files change

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,5 +1,8 @@
 name: Lighthouse
-on: [pull_request]
+on:
+  pull_request:
+    paths:
+      - 'src/**'
 
 jobs:
   lhci:


### PR DESCRIPTION
## Description
Reduce the delay between PR creation and CI finishing (especially for Dependabot PRs) by only running the Lighthouse workflow if `src` files change.

## Developer Checklist
- [ ] All GitHub status checks pass
- [ ] Commits are squashed and rebased on top of the target branch

