### PR TITLE
chore: ignore `.env` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+.env


### PR DESCRIPTION
## Description
Other branches might end up using `.env` files. We want to ignore those always, regardless of branch.

## Developer Checklist
- [ ] All GitHub status checks pass
- [ ] Commits are squashed and rebased on top of the target branch
